### PR TITLE
PoC at implementing IntPtrUString with SafeHandle

### DIFF
--- a/NStackTests/ustringTest.cs
+++ b/NStackTests/ustringTest.cs
@@ -195,7 +195,7 @@ namespace NStackTests
 		public void TestBlockRelease ()
 		{
 			bool released = false;
-			Action<ustring, IntPtr> releaseFunc = (str, block) => {
+			Action<IntPtr> releaseFunc = (block) => {
 				released = true;
 			};
 			var ptr = Marshal.AllocHGlobal (10);


### PR DESCRIPTION
The added advantage is that every subslice of a given ustring will keep a reference to the native pointer, so we have automatic memory management for all the native values. Thus, we know that we can release the handle safely even if it's shared between instances.
We also gain the advantage of the string wrappers being reclaimable, only the shared safehandle instance will remain in memory.