### PR TITLE
Upgrade to more SDK-style and latest NuGetizer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Temporary workaround for https://github.com/NuGet/Home/issues/5300 -->
+  <Import Project="$(VsInstallRoot)\Common7\IDE\Extensions\5y0bse3d.tbd\NuGet.targets"
+            Condition="'$(IsRestoreTargetsFileLoaded)' != 'true' and Exists('$(VsInstallRoot)\Common7\IDE\Extensions\5y0bse3d.tbd\NuGet.targets')" />
+</Project>

--- a/NStack.sln
+++ b/NStack.sln
@@ -1,9 +1,15 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NStack", "NStack\NStack.csproj", "{844D229D-99C7-46EE-879A-730F115BA309}"
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.6
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NStack", "NStack\NStack.csproj", "{844D229D-99C7-46EE-879A-730F115BA309}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NStackTests", "NStackTests\NStackTests.csproj", "{21125504-5F4D-48A3-8978-A552627A8D26}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NStackTests", "NStackTests\NStackTests.csproj", "{21125504-5F4D-48A3-8978-A552627A8D26}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F96D8585-4375-4480-BACC-12D8C6301A4A}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,6 +25,9 @@ Global
 		{21125504-5F4D-48A3-8978-A552627A8D26}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{21125504-5F4D-48A3-8978-A552627A8D26}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{21125504-5F4D-48A3-8978-A552627A8D26}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/NStack/Directory.Build.targets
+++ b/NStack/Directory.Build.targets
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Disable built-in SDK Pack -->
+    <!-- For pre-15.3, you need to pass this via envvars or /p:NuGetBuildTasksPackTargets=NO-SDK -->
+    <NuGetBuildTasksPackTargets>NO-SDK-PACK</NuGetBuildTasksPackTargets>
+
+    <!-- Turn on pack on Release builds. Don't turn on if legacy pack is active, as it causes circular dependency failure. -->
+    <PackOnBuild Condition="'$(Configuration)' == 'Release' and '$(GenerateNuspecDependsOn)' == ''">true</PackOnBuild>
+  </PropertyGroup>
+
+  <Target Name="FailForLegacyPack" BeforeTargets="Pack" Condition="'$(GenerateNuspecDependsOn)' != ''">
+    <Error Text="You intended to use NuGetizer Pack, but ended up with the .NET SDK Pack. Please either use a 15.3+ version of Visual Studio/MSBuild or set NuGetBuildTasksPackTarget=NO-SDK-PACK via environment variables or /p: on the command line." />
+  </Target>
+</Project>

--- a/NStack/NStack.csproj
+++ b/NStack/NStack.csproj
@@ -1,11 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\packages\NuGet.Build.Packaging.0.1.248\build\NuGet.Build.Packaging.props" Condition="Exists('..\packages\NuGet.Build.Packaging.0.1.248\build\NuGet.Build.Packaging.props')" />
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFrameworks>netstandard1.5;net461</TargetFrameworks>
+
     <PackageId>NStack.Core</PackageId>
-    <PackageVersion>0.2</PackageVersion>
+    <PackageVersion>0.2.0</PackageVersion>
     <Authors>Miguel de Icaza</Authors>
     <PackageLicenseUrl>https://github.com/migueldeicaza/NStack/blob/master/LICENSE.md</PackageLicenseUrl>
     <Owners>Miguel de Icaza</Owners>
@@ -13,24 +11,49 @@
     <Summary>NStack.Core brings a set of updated APIs to .NET including a UTF8-string aware string.</Summary>
     <PackageTags>unicode, c#</PackageTags>
     <Title>NStack.Core</Title>
-    <Description>NStack.Core brings a set of updated APIs to .NET.  
+    <Description>
+      NStack.Core brings a set of updated APIs to .NET.
 
-It starts with a new string type that is focused on Unicode code-points as opposed to the historical chars and  UTF-16 encoding and introduces a utf8 string that supports slicing</Description>
+      It starts with a new string type that is focused on Unicode code-points as opposed to the historical chars and  UTF-16 encoding and introduces a utf8 string that supports slicing
+    </Description>
+
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReleaseVersion>0.3</ReleaseVersion>
   </PropertyGroup>
-    
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>bin\Debug\netstandard1.6\NStack.xml</DocumentationFile>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <!-- When everything is documented, this can be moved to the global property group as-is -->
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\NStack.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <PackageReference Include="NuGet.Build.Packaging" Version="0.1.306" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
-  <Import Project="..\packages\NuGet.Build.Packaging.0.1.248\build\NuGet.Build.Packaging.targets" Condition="Exists('..\packages\NuGet.Build.Packaging.0.1.248\build\NuGet.Build.Packaging.targets')" />
+
+  <ItemGroup>
+    <!-- Explicitly list dependencies for other TFMs to make packages.config users happy -->
+    <PackageFile Include="NETStandard.Library" Version="1.6.1" Kind="Dependency" TargetFramework="netstandard1.0" />
+    <PackageFile Include="System.ValueTuple" Version="4.3.1" Kind="Dependency" TargetFramework="netstandard1.0" />
+    <!-- Dummy ones to avoid showing the large nuget package dependencies installs -->
+    <PackageFile Include="_._" Version="1.0.0" Kind="Dependency" TargetFramework="net" />
+    <PackageFile Include="_._" Version="1.0.0" Kind="Dependency" TargetFramework="win" />
+    <PackageFile Include="_._" Version="1.0.0" Kind="Dependency" TargetFramework="wp" />
+    <PackageFile Include="_._" Version="1.0.0" Kind="Dependency" TargetFramework="wpa" />
+    <PackageFile Include="_._" Version="1.0.0" Kind="Dependency" TargetFramework="MonoAndroid10" />
+    <PackageFile Include="_._" Version="1.0.0" Kind="Dependency" TargetFramework="Xamarin.iOS10" />
+    <PackageFile Include="_._" Version="1.0.0" Kind="Dependency" TargetFramework="Xamarin.Mac20" />
+    <PackageFile Include="_._" Version="1.0.0" Kind="Dependency" TargetFramework="portable-net45+win+wpa81+wp80" />
+    <PackageFile Include="_._" Version="1.0.0" Kind="Dependency" TargetFramework="uap" />
+    <PackageFile Include="_._" Version="1.0.0" Kind="Dependency" TargetFramework="dotnet" />
+    <PackageFile Include="_._" Version="1.0.0" Kind="Dependency" TargetFramework="xamarintvos" />
+    <PackageFile Include="_._" Version="1.0.0" Kind="Dependency" TargetFramework="xamarinwatchos" />
+  </ItemGroup>
+
+  <!-- Our project is cross-targeting just so the tests can run against net461. But for 
+		 Pack, we want to pack only netstandard.
+	-->
+  <Target Name="Pack">
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Pack" Properties="TargetFramework=netstandard1.5" />
+  </Target>
 </Project>

--- a/NStack/packages.config
+++ b/NStack/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NuGet.Build.Packaging" version="0.1.248" targetFramework="net461" developmentDependency="true" />
-  <package id="System.ValueTuple" version="4.3.1" targetFramework="net461" />
-</packages>

--- a/NStackTests/NStackTests.csproj
+++ b/NStackTests/NStackTests.csproj
@@ -1,54 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{21125504-5F4D-48A3-8978-A552627A8D26}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>NStackTests</RootNamespace>
-    <AssemblyName>NStackTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFramework>net461</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReleaseVersion>0.3</ReleaseVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
+    <PackageReference Include="NUnit" Version="3.7.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ustringTest.cs" />
-    <Compile Include="Utf8Test.cs" />
-    <Compile Include="UnicodeTest.cs" />
+    <ProjectReference Include="..\NStack\NStack.csproj" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\NStack\NStack.csproj">
-      <Project>{844D229D-99C7-46EE-879A-730F115BA309}</Project>
-      <Name>NStack</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/NStackTests/packages.config
+++ b/NStackTests/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="3.6.1" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.3.1" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
Changes include:
- Adding the empty dependency groups via the built-in supported mechanism
  in NuGetizer (`<PackageFile Kind=Dependency Id=_._`)
- Replacing usage of packages.config for PackageReference in both projects
- Adding NuGet restore workaround for VS2017 Version 15.3.0 Preview 2.0 [26530.1.d15rel]
  where it's broken right now (see https://github.com/NuGet/Home/issues/5300)