### PR TITLE
Rename internal references: gui-cs → tui-cs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing to NStack
 
-We welcome contributions from the community. See [Issues](https://github.com/gui-cs/NStack/issues) for a list of open [bugs](https://github.com/gui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Abug) and [enhancements](https://github.com/gui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement). Contributors looking for something fun to work on should look at issues tagged as:
+We welcome contributions from the community. See [Issues](https://github.com/tui-cs/NStack/issues) for a list of open [bugs](https://github.com/tui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Abug) and [enhancements](https://github.com/tui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement). Contributors looking for something fun to work on should look at issues tagged as:
 
-- [good first issue](https://github.com/gui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
-- [up for grabs](https://github.com/gui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs)
-- [help wanted](https://github.com/gui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs)
+- [good first issue](https://github.com/tui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+- [up for grabs](https://github.com/tui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs)
+- [help wanted](https://github.com/tui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs)
 
 ## Forking and Submitting Changes
 
@@ -15,7 +15,7 @@ NStack uses the [GitFlow](https://nvie.com/posts/a-successful-git-branching-mode
 
 ### Forking NStack
 
-1. Use GitHub to fork the `NStack` repo to your account (https://github.com/gui-cs/NStack/fork).
+1. Use GitHub to fork the `NStack` repo to your account (https://github.com/tui-cs/NStack/fork).
 
 2. Clone your fork to your local machine
 
@@ -27,13 +27,13 @@ Now, your local repo will have an `origin` remote pointing to `https://github.co
 
 3. Add a remote for `upstream`: 
 ```
-git remote add upstream https://github.com/gui-cs/NStack
+git remote add upstream https://github.com/tui-cs/NStack
 ```
 You now have your own fork and a local repo that references it as `origin`. Your local repo also now references the orignal NStack repo as `upstream`. 
 
 ### Starting to Make a Change
 
-Ensure your local `develop` branch is up-to-date with `upstream` (`github.com/gui-cs/NStack`):
+Ensure your local `develop` branch is up-to-date with `upstream` (`github.com/tui-cs/NStack`):
 ```powershell
 cd ./NStack
 git checkout develop
@@ -92,16 +92,16 @@ Follow the template instructions found on Github.
 
 ## NStack Coding Style
 
-**NStack** follows the [Mono Coding Guidelines](https://www.mono-project.com/community/contributing/coding-guidelines/). [`/.editorconfig`](https://github.com/gui-cs/NStack/blob/b0a43ba338adf5ec069066e5a7dff8fea39b41db/.editorconfig) enforces this style in Visual Studio. Use `Ctrl-K-D` in Visual Studio to have it reformat code.
+**NStack** follows the [Mono Coding Guidelines](https://www.mono-project.com/community/contributing/coding-guidelines/). [`/.editorconfig`](https://github.com/tui-cs/NStack/blob/b0a43ba338adf5ec069066e5a7dff8fea39b41db/.editorconfig) enforces this style in Visual Studio. Use `Ctrl-K-D` in Visual Studio to have it reformat code.
 
 ## User Experience Tenets
 
 **NStack**, as a UI framework, heavily influences how console graphical user interfaces (GUIs) work. We use the following [tenets](https://ceklog.kindel.com/2020/02/10/tenets/) to guide us:
 
-*NOTE: Like all tenets, these are up for debate. If you disagree, have questions, or suggestions about these tenets and guidelines submit an Issue using the [design](https://github.com/gui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Adesign) tag.*
+*NOTE: Like all tenets, these are up for debate. If you disagree, have questions, or suggestions about these tenets and guidelines submit an Issue using the [design](https://github.com/tui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Adesign) tag.*
 
 1. **Honor What's Come Before**. The Mac and Windows OS's have well-established GUI idioms that are mostly consistent. We adhere to these versus inventing new ways for users to do things. For example, **NStack** adopts the `ctrl/command-c`, `ctrl/command-v`, and `ctrl/command-x` keyboard shortcuts for cut, copy, and paste versus defining new shortcuts.
-2. **Consistency Matters**. Common UI idioms should be consistent across the GUI framework. For example, `ctrl/command-q` quits/exits all modal views. See [Issue #456](https://github.com/gui-cs/NStack/issues/456) as a counter-example that should be fixed.
+2. **Consistency Matters**. Common UI idioms should be consistent across the GUI framework. For example, `ctrl/command-q` quits/exits all modal views. See [Issue #456](https://github.com/tui-cs/NStack/issues/456) as a counter-example that should be fixed.
 3. **Honor the OS, but Work Everywhere**. **NStack** is cross-platform, but we support taking advantage of a platform's unique advantages. For example, the Windows Console API is richer than the Unix API in terms of keyboard handling. Thus, in Windows pressing the `alt` key in a **NStack** app will activate the `MenuBar`, but in Unix, the user has to press the full hotkey (e.g. `alt-f`) or `F9`. 
 4. **Keyboard first, Mouse also**. Users use consoles primarily with the keyboard; **NStack** is optimized for getting stuff done without using the Mouse. However, as a GUI framework, the Mouse is essential thus we strive to ensure that everything also works via the Mouse.
 
@@ -109,40 +109,40 @@ Follow the template instructions found on Github.
 
 **NStack** provides an API that is used by many. As the project evolves, contributors should follow these [tenets](https://ceklog.kindel.com/2020/02/10/tenets/) to ensure Consistency and backward compatibility.
 
-*NOTE: Like all tenets, these are up for debate. If you disagree, have questions, or suggestions about these tenets and guidelines submit an Issue using the [design](https://github.com/gui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Adesign) tag.*
+*NOTE: Like all tenets, these are up for debate. If you disagree, have questions, or suggestions about these tenets and guidelines submit an Issue using the [design](https://github.com/tui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Adesign) tag.*
 
 1. **Stand on the shoulders of giants.** Follow the [Microsoft .NET Framework Design Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/) where appropriate. 
 2. **Don't Break Existing Stuff.** Avoid breaking changes to user behavior or the public API; instead, figure out how to implement new functionality in a similar way. If a breaking change can't be avoided, follow the guidelines below.
 3. **Fail-fast.** Fail-fast makes bugs and failures appear sooner, leading to a higher-quality framework and API.
-4. **Standards Reduce Complexity**. We strive to adopt standard API idoms because doing so reduces complexity for users of the API. For example, see Tenet #1 above. A counterexample is [Issue #447](https://github.com/gui-cs/NStack/issues/447).
+4. **Standards Reduce Complexity**. We strive to adopt standard API idoms because doing so reduces complexity for users of the API. For example, see Tenet #1 above. A counterexample is [Issue #447](https://github.com/tui-cs/NStack/issues/447).
 
 ### Include API Documentation
 
-Great care has been provided thus far in ensuring **NStack** has great [API Documentation](https://gui-cs.github.io/NStack/api/NStack/NStack.html). Contributors have the responsibility of continuously improving the API Documentation.
+Great care has been provided thus far in ensuring **NStack** has great [API Documentation](https://tui-cs.github.io/NStack/api/NStack/NStack.html). Contributors have the responsibility of continuously improving the API Documentation.
 
 - All public APIs must have clear, concise, and complete documentation in the form of [XML Documentation](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/).
 - Keep the `<summary></summary>` terse.
 - Use `<see cref=""/>` liberally to cross-link topics.
 - Use `<remarks></remarks>` to add more context and explanation.
-- For complex topics, provide conceptual documentation in the `docfx/articles` folder as a `.md` file. It will automatically get picked up and be added to [Conceptual Documentation](https://gui-cs.github.io/NStack/articles/index.html).
+- For complex topics, provide conceptual documentation in the `docfx/articles` folder as a `.md` file. It will automatically get picked up and be added to [Conceptual Documentation](https://tui-cs.github.io/NStack/articles/index.html).
 - Use proper English and good grammar.
 
 ## Breaking Changes to User Behavior or the Public API
 
-- Tag all pull requests that cause breaking changes to user behavior or the public API with the [breaking-change](https://github.com/gui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Abreaking-change) tag. This will help project maintainers track and document these.
-- Add a `<remark></remark>` to the XML Documentation to the code describing the breaking change. These will get picked up in the [API Documentation](https://gui-cs.github.io/NStack/api/NStack/NStack.html).
+- Tag all pull requests that cause breaking changes to user behavior or the public API with the [breaking-change](https://github.com/tui-cs/NStack/issues?q=is%3Aopen+is%3Aissue+label%3Abreaking-change) tag. This will help project maintainers track and document these.
+- Add a `<remark></remark>` to the XML Documentation to the code describing the breaking change. These will get picked up in the [API Documentation](https://tui-cs.github.io/NStack/api/NStack/NStack.html).
 
 ## Unit Tests
 
 PRs should never cause code coverage to go down. Ideally, every PR will get the project closer to 100%. PRs that include new functionality (e.g. a new control) should have at least 70% code coverage for the new functionality. 
 
-**NStack** has an automated unit or regression test suite. See the [Testing wiki](https://github.com/gui-cs/NStack/wiki/Testing).
+**NStack** has an automated unit or regression test suite. See the [Testing wiki](https://github.com/tui-cs/NStack/wiki/Testing).
 
 We analyze unit tests and code coverage on each PR push. 
 
 The code coverage of the latest released build (on NuGet) is shown as a badge at the top of `README.md`. Here as well:
 
-![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/gui-cs/90ef67a684cb71db1817921a970f8d27/raw/code-coverage.json)
+![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/tui-cs/90ef67a684cb71db1817921a970f8d27/raw/code-coverage.json)
 
 The project uses Fine Code Coverage to allow easy access to code coverage info on a per-component basis.
 

--- a/NStack/NStack.csproj
+++ b/NStack/NStack.csproj
@@ -10,8 +10,8 @@
     <PackageTags>unicode, c#</PackageTags>
     <Title>NStack.Core</Title>
 
-    <PackageProjectUrl>https://github.com/gui-cs/NStack/</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/gui-cs/NStack.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/tui-cs/NStack/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/tui-cs/NStack.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -26,7 +26,7 @@
 
 It starts with a new string type that is focused on Unicode code-points as opposed to the historical chars and  UTF-16 encoding and introduces a utf8 string that supports slicing</Description>
     <PackageReleaseNotes>
-      See https://github.com/gui-cs/NStack/releases
+      See https://github.com/tui-cs/NStack/releases
     </PackageReleaseNotes>
 
     <!-- Version numbers are automatically updated by gitversion when a release is released -->

--- a/NStack/README.md
+++ b/NStack/README.md
@@ -39,7 +39,7 @@ Doing so will update the `.csproj` files in your branch with version info, which
 ## Deploying a new version of the NStack Nuget Library
 
 To release a new version (e.g. with a higher `major`, `minor`, or `patch` value) tag a commit using `git tag` and then 
-push that tag directly to the `main` branch on `github.com/gui-cs/NStack` (`upstream`).
+push that tag directly to the `main` branch on `github.com/tui-cs/NStack` (`upstream`).
 
 The `tag` must be of the form `v<major>.<minor>.<patch>`, e.g. `v2.3.4`.
 
@@ -101,12 +101,12 @@ git push --atomic upstream main v2.3.4
 
 ### 8) Monitor Github Actions to ensure the Nuget publishing worked.
 
-https://github.com/gui-cs/NStack/actions
+https://github.com/tui-cs/NStack/actions
 
 ### 9) Check Nuget to see the new package version (wait a few minutes) 
 https://www.nuget.org/packages/NStack.Core
 
-### 10) Add a new Release in Github: https://github.com/gui-cs/NStack/releases
+### 10) Add a new Release in Github: https://github.com/tui-cs/NStack/releases
 
 Generate release notes with the list of PRs since the last release 
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # NStack
 
-![Build](https://github.com/gui-cs/NStack/actions/workflows/build.yml/badge.svg)
+![Build](https://github.com/tui-cs/NStack/actions/workflows/build.yml/badge.svg)
 [![Version](https://img.shields.io/nuget/v/NStack.Core.svg)](https://www.nuget.org/packages/NStack.Core)
 [![Downloads](https://img.shields.io/nuget/dt/NStack.Core)](https://www.nuget.org/packages/NStack.Core)
-[![License](https://img.shields.io/github/license/gui-cs/NStack.svg)](LICENSE)
-![Bugs](https://img.shields.io/github/issues/gui-cs/NStack)
+[![License](https://img.shields.io/github/license/tui-cs/NStack.svg)](LICENSE)
+![Bugs](https://img.shields.io/github/issues/tui-cs/NStack)
 
-NOTE: NStack has moved to the [gui-cs org](https://github.com/orgs/gui-cs/).
+NOTE: NStack has moved to the [tui-cs org](https://github.com/orgs/tui-cs/).
 
 Currently, this library contains a port of the Go string, and Go rune support as well as other Unicode helper methods.
 
-You can browse the [API documentation](https://gui-cs.github.io/NStack).
+You can browse the [API documentation](https://tui-cs.github.io/NStack).
 
 Install the [NuGet package from NuGet.org](https://www.nuget.org/packages/NStack.Core) by installing `NStack.Core`.
 

--- a/docfx/README.md
+++ b/docfx/README.md
@@ -1,6 +1,6 @@
 This folder generates the API docs for NStack. 
 
-The API documentation is generated via a GitHub Action (`.github/workflows/api-docs.yml`) using [DocFX](https://github.com/dotnet/docfx). The Action publishes the docs to the `gh-pages` branch, which gets published to https://gui-cs.github.io/NStack/.
+The API documentation is generated via a GitHub Action (`.github/workflows/api-docs.yml`) using [DocFX](https://github.com/dotnet/docfx). The Action publishes the docs to the `gh-pages` branch, which gets published to https://tui-cs.github.io/NStack/.
 
 ## To Generate the Docs Locally
 

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -70,7 +70,7 @@
       "_appLogoPath": "images/logo48.png",
       "_disableContribution": false,
       "_gitContribute": {
-        "repo": "https://github.com/gui-cs/NStack",
+        "repo": "https://github.com/tui-cs/NStack",
         "branch": "develop",
         "apiSpecFolder": "docfx/overrides"
       },

--- a/docfx/toc.yml
+++ b/docfx/toc.yml
@@ -4,4 +4,4 @@
   href: api/NStack/
   homepage: api/NStack/NStack.html
 - name: Source
-  href: https://github.com/gui-cs/NStack
+  href: https://github.com/tui-cs/NStack


### PR DESCRIPTION
Closes #92.

Part of the org-wide rename **gui-cs → tui-cs**. GitHub auto-redirects all `github.com/gui-cs/*` URLs; this updates *internal* references for self-consistency.

## What changed
7 files. Rule: every **`gui-cs`** (hyphen — org login) → **`tui-cs`**. Historical brand **`gui.cs`** (dot) left as-is. Machine-local absolute paths left untouched.

Functional: `NStack/NStack.csproj` package metadata (`PackageProjectUrl`, `RepositoryUrl`) and `docfx/docfx.json` repo URL updated. Workflows contained no `gui-cs` references. No coupled tests. Remainder are doc/badge URLs and the `gui-cs.github.io` docs domain.

## ⚠️ DRAFT until after the rename
Prep-first. Do not merge before the org rename.